### PR TITLE
fix URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots are [here](screenshots.md)
 ```
  # Download your favorite theme ~/.emacs.d
  % cd ~/.emacs.d
- % curl -O https://raw.github.com/emacs-jp/replace-colorthemes/master/aalto-dark-theme.el
+ % curl -O https://raw.githubusercontent.com/emacs-jp/replace-colorthemes/master/aalto-dark-theme.el
 ```
 
 And add theme configuration to you configuration file


### PR DESCRIPTION
fix invalid URL.
GitHub's user content domain has changed.
https://developer.github.com/changes/2014-04-25-user-content-security/