### PR TITLE
add color-theme-modern.el library

### DIFF
--- a/color-theme-modern.el
+++ b/color-theme-modern.el
@@ -1,0 +1,30 @@
+;;; color-theme-modern.el --- ports of color-theme themes to deftheme
+
+;; Copyright (C) 2013-2016 by Syohei YOSHIDA
+
+;; Author: Syohei YOSHIDA <syohex@gmail.com>
+;; URL: https://github.com/emacs-jp/replace-colorthemes
+;; Version: 0.01
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This package ports many `color-theme' themes to `deftheme' themes.
+
+;;; Code:
+
+(provide 'color-theme-modern)
+
+;;; color-theme-modern.el ends here


### PR DESCRIPTION
A package should provide a library matching its name.  The commentary
of that library is then used as the description for the package as it
appears on Melpa.

(You might want to additionally improve the commentary.)