### PR TITLE
subdued-theme: Change nil :foreground values to unspecified

### DIFF
--- a/subdued-theme.el
+++ b/subdued-theme.el
@@ -69,8 +69,8 @@
  '(show-paren-mismatch-face ((t (:foreground "#2e3436" :background "#ef2929"))))
 
  ;; Line highlighting
- '(highlight ((t (:background "#1f1f1f" :foreground nil))))
- '(highlight-current-line-face ((t (:background "#1f1f1f" :foreground nil))))
+ '(highlight ((t (:background "#1f1f1f" :foreground unspecified))))
+ '(highlight-current-line-face ((t (:background "#1f1f1f" :foreground unspecified))))
 
  ;; Calendar
  '(holiday-face ((t (:foreground "#cc0000")))) ; dark scarlet red


### PR DESCRIPTION
Stops message: 

> Warning: setting attribute ‘:foreground’ of face ‘highlight’: nil value is invalid, use ‘unspecified’ instead.